### PR TITLE
Room Header 구현

### DIFF
--- a/src/components/RoomHeader.tsx
+++ b/src/components/RoomHeader.tsx
@@ -1,0 +1,31 @@
+type Props = {
+  title: string;
+  roomCode: number;
+};
+
+const RoomHeader = ({ title, roomCode }: Props) => {
+  const date = new Date();
+  const formatted = date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  return (
+    <div className="w-full py-4 px-1 flex justify-between items-end border-b-2 border-[#CFCFCF]">
+      <div className="flex flex-col gap-1 justify-center text-[var(--color-gray-2)]">
+        <span className="text-sm">Date</span>
+        <div className="font-semibold text-xl">{formatted}</div>
+      </div>
+      <span className="text-2xl font-semibold">{title}</span>
+      <div className="flex flex-col gap-1 justify-center items-end text-[var(--color-gray-2)]">
+        <span className="text-sm">Enter Code</span>
+        <div className="font-semibold text-xl text-[var(--color-primary)]">
+          #{roomCode}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RoomHeader;

--- a/src/components/RoomHeader.tsx
+++ b/src/components/RoomHeader.tsx
@@ -12,12 +12,14 @@ const RoomHeader = ({ title, roomCode }: Props) => {
   });
 
   return (
-    <div className="w-full py-4 px-1 flex justify-between items-end border-b-2 border-[#CFCFCF]">
+    <div className="w-full py-4 px-1 flex justify-between items-end relative border-b-2 border-[#CFCFCF]">
       <div className="flex flex-col gap-1 justify-center text-[var(--color-gray-2)]">
         <span className="text-sm">Date</span>
         <div className="font-semibold text-xl">{formatted}</div>
       </div>
-      <span className="text-2xl font-semibold">{title}</span>
+      <span className="absolute left-1/2 -translate-x-1/2 text-2xl font-semibold">
+        {title}
+      </span>
       <div className="flex flex-col gap-1 justify-center items-end text-[var(--color-gray-2)]">
         <span className="text-sm">Enter Code</span>
         <div className="font-semibold text-xl text-[var(--color-primary)]">

--- a/src/index.css
+++ b/src/index.css
@@ -7,5 +7,6 @@ body {
   }
   --color-primary: #33c4a8;
   --color-gray: #d9d9d9;
+  --color-gray-2: #737373;
   --color-error: #ed4337;
 }

--- a/src/pages/test.tsx
+++ b/src/pages/test.tsx
@@ -2,12 +2,13 @@
 import RoomHeader from '../components/RoomHeader';
 const TestPage = () => {
   return (
-    <div className="w-full flex items-center justify-center py-20 border-2 border-red-700">
+    <div className="w-full flex items-center justify-center py-20">
       <div
-        className="w-3/5 flex items-center justify-center
-      border-2 border-[var(--color-gray)]"
+        className="w-3/5 flex flex-col items-center justify-center
+      "
       >
         <RoomHeader title={'Hooks 파헤치기'} roomCode={1234} />
+        <h1 className="text-4xl font-bold">Router Test Page</h1>
       </div>
     </div>
   );

--- a/src/pages/test.tsx
+++ b/src/pages/test.tsx
@@ -1,7 +1,14 @@
+// Header Test Page
+import RoomHeader from '../components/RoomHeader';
 const TestPage = () => {
   return (
-    <div className="container">
-      <h1 className="text-4xl font-bold">Router Test Page</h1>
+    <div className="w-full flex items-center justify-center py-20 border-2 border-red-700">
+      <div
+        className="w-3/5 flex items-center justify-center
+      border-2 border-[var(--color-gray)]"
+      >
+        <RoomHeader title={'Hooks 파헤치기'} roomCode={1234} />
+      </div>
     </div>
   );
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import Layout from '../Layout.tsx'; // 새로 만든 Layout
+import Layout from '../Layout.tsx';
 import HomePage from '../pages/index';
 import Test from '../pages/test.tsx';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,6 @@
   ],
   "compilerOptions":
   {
-    "types": ["vite-plugin-svgr/client"] // 이부분 추가
+    "types": ["vite-plugin-svgr/client"]
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#15 

## 📝작업 내용
### /components
- RoomHeader.tsx
  - 부모 요소에 맞게 너비가 조정되도록 함
  - space-between 을 통해 간격이 제대로 조정되지 않아 title 을 absolute 로 배치하였음.
  - props 를 통해 title 과 code 를 받아 처리하도록 함
  - 현재 날짜 기준으로 date 를 설정하여 포매팅하도록 하였음.

<img width="982" alt="image" src="https://github.com/user-attachments/assets/a89dd821-11fb-4f37-8a6d-2c4855718167" />
