### PR TITLE
feat: 관리자 페이지 구현

### DIFF
--- a/src/assets/CheckSmall.tsx
+++ b/src/assets/CheckSmall.tsx
@@ -1,0 +1,29 @@
+const CheckSmall = () => {
+  return (
+    <div className="transition-colors duration-300 ease-in-out text-inherit">
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 68 64"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <ellipse
+          cx="33.9418"
+          cy="32"
+          rx="31.6098"
+          ry="30"
+          stroke="currentColor"
+          stroke-width="4"
+        />
+        <path
+          d="M19.8927 32L30.4293 42L47.9902 22"
+          stroke="currentColor"
+          stroke-width="4"
+        />
+      </svg>
+    </div>
+  );
+};
+
+export default CheckSmall;

--- a/src/components/AdminQuestion.tsx
+++ b/src/components/AdminQuestion.tsx
@@ -16,12 +16,8 @@ export const AdminQuestion = ({
   isAdmin,
   roomTitle,
 }: QuestionProps) => {
-  const [selectedBox, setSelectedBox] = useState(is_selected);
-
-  //선택한 질문 하이라이팅
   const handleBoxClick = () => {
-    if (!isAdmin) return;
-    setSelectedBox((prev) => !prev);
+    // Todo : 방 이동 처리
   };
 
   const formatDate = (dateStr: string) => {
@@ -36,16 +32,20 @@ export const AdminQuestion = ({
       created_at.slice(11, 16)
     );
   };
+  console.log('isAdmin', isAdmin);
 
   return (
     <div
       onClick={handleBoxClick}
       className={`flex flex-row w-full h-fit py-4 px-8 rounded-2xl shadow-[0_0_4px_1px_rgba(51,196,168,0.75)] 
-        ${selectedBox ? 'bg-[#E1F4F0]' : 'bg-white'}
-        ${isAdmin ? 'cursor-pointer' : ''}
+        ${isAdmin ? 'cursor-pointer border-[var(--color-primary)] bg-[#E1F4F0]' : 'bg-white'}
       `}
     >
-      <div className="w-full h-full flex justify-between">
+      <div
+        className={`w-full h-full flex justify-between 
+        ${isAdmin ? 'py-4' : ''}
+        `}
+      >
         <div className="flex flex-col gap-3 flex-1">
           <div className="flex flex-row gap-4 items-center">
             <div className="w-8 h-fit justify-center items-center ">

--- a/src/components/AdminQuestion.tsx
+++ b/src/components/AdminQuestion.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { UserIcon } from '../assets/UserIcon';
+import { type QuestionType } from '../apis/questions';
+
+interface QuestionProps extends QuestionType {
+  isAdmin: boolean;
+  isEditable: boolean;
+  complete: boolean;
+  roomTitle: string;
+}
+
+export const AdminQuestion = ({
+  text,
+  created_at,
+  is_selected,
+  isAdmin,
+  roomTitle,
+}: QuestionProps) => {
+  const [selectedBox, setSelectedBox] = useState(is_selected);
+
+  //선택한 질문 하이라이팅
+  const handleBoxClick = () => {
+    if (!isAdmin) return;
+    setSelectedBox((prev) => !prev);
+  };
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return (
+      date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      }) +
+      ' ' +
+      created_at.slice(11, 16)
+    );
+  };
+
+  return (
+    <div
+      onClick={handleBoxClick}
+      className={`flex flex-row w-full h-fit py-4 px-8 rounded-2xl shadow-[0_0_4px_1px_rgba(51,196,168,0.75)] 
+        ${selectedBox ? 'bg-[#E1F4F0]' : 'bg-white'}
+        ${isAdmin ? 'cursor-pointer' : ''}
+      `}
+    >
+      <div className="w-full h-full flex justify-between">
+        <div className="flex flex-col gap-3 flex-1">
+          <div className="flex flex-row gap-4 items-center">
+            <div className="w-8 h-fit justify-center items-center ">
+              <UserIcon />
+            </div>
+            <div className="flex flex-col">
+              <p className="text-[16px] font-[500]">
+                {text ? 'Annonymous' : roomTitle}
+              </p>
+              <p className="text-[14px] text-[#737373]">
+                {text ? created_at.slice(11, 16) : formatDate(created_at)}
+              </p>
+            </div>
+          </div>
+          {text}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/RoomHeader.tsx
+++ b/src/components/RoomHeader.tsx
@@ -6,27 +6,34 @@ type Props = {
 
 const RoomHeader = ({ title, roomCode, dateStr }: Props) => {
   const date = new Date(dateStr);
-  const formatted = date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
+  const formatted =
+    date instanceof Date && !isNaN(date.getTime())
+      ? date.toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        })
+      : '';
 
   return (
     <div className="w-full py-4 px-1 flex justify-between items-end relative border-b-2 border-[#CFCFCF]">
-      <div className="flex flex-col gap-1 justify-center text-[var(--color-gray-2)]">
-        <span className="text-sm">Date</span>
-        <div className="font-semibold text-xl">{formatted}</div>
-      </div>
+      {formatted && (
+        <div className="flex flex-col gap-1 justify-center text-[var(--color-gray-2)]">
+          <span className="text-sm">Date</span>
+          <div className="font-semibold text-xl">{formatted}</div>
+        </div>
+      )}
       <span className="absolute left-1/2 -translate-x-1/2 text-2xl font-semibold">
         {title}
       </span>
-      <div className="flex flex-col gap-1 justify-center items-end text-[var(--color-gray-2)]">
-        <span className="text-sm">Enter Code</span>
-        <div className="font-semibold text-xl text-[var(--color-primary)]">
-          #{roomCode}
+      {formatted && (
+        <div className="flex flex-col gap-1 justify-center items-end text-[var(--color-gray-2)]">
+          <span className="text-sm">Enter Code</span>
+          <div className="font-semibold text-xl text-[var(--color-primary)]">
+            #{roomCode}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/components/RoomHeader.tsx
+++ b/src/components/RoomHeader.tsx
@@ -6,14 +6,13 @@ type Props = {
 
 const RoomHeader = ({ title, roomCode, dateStr }: Props) => {
   const date = new Date(dateStr);
-  const formatted =
-    date instanceof Date && !isNaN(date.getTime())
-      ? date.toLocaleDateString('en-US', {
-          year: 'numeric',
-          month: 'short',
-          day: 'numeric',
-        })
-      : '';
+  const formatted = !isNaN(date.getTime())
+    ? date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      })
+    : '';
 
   return (
     <div className="w-full py-4 px-1 flex justify-between items-end relative border-b-2 border-[#CFCFCF]">

--- a/src/pages/admin/questions.tsx
+++ b/src/pages/admin/questions.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import RoomHeader from '../../components/RoomHeader';
+import { useSearchParams } from 'react-router-dom';
+import { downloadFile } from '../../apis/room.ts';
+import { AdminQuestion } from '../../components/AdminQuestion.tsx';
+
+export type Room = {
+  id: string | null;
+  code: string;
+  title: string;
+  created_at: string;
+  file_name: string;
+  room_title: string;
+};
+
+const AdminQuestions = () => {
+  const dumpData = [
+    {
+      question_id: 1,
+      text: '프론트엔드와 백엔드의 가장 큰 차이점은 무엇인가요?',
+      created_at: '2025-05-16T09:00:00Z',
+      is_selected: false,
+      likes: 12,
+    },
+    {
+      question_id: 2,
+      text: 'React에서 상태 관리를 어떤 방식으로 하나요?',
+      created_at: '2025-05-16T09:15:00Z',
+      is_selected: false,
+      likes: 25,
+    },
+    {
+      question_id: 3,
+      text: 'CORS 에러는 왜 발생하고 어떻게 해결하나요?',
+      created_at: '2025-05-16T09:30:00Z',
+      is_selected: false,
+      likes: 8,
+    },
+    {
+      question_id: 4,
+      text: 'TypeScript의 유틸리티 타입 중 가장 자주 쓰는 것은?',
+      created_at: '2025-05-16T09:45:00Z',
+      is_selected: false,
+      likes: 17,
+    },
+  ];
+  const [roomInfo, setRoomInfo] = useState<Room>({
+    id: '-1',
+    code: '-1',
+    title: '강의 제목',
+    created_at: '',
+    file_name: '',
+    room_title: '',
+  });
+  const [searchParams] = useSearchParams();
+
+  const roomId = searchParams.get('room-id');
+  const enterCode = searchParams.get('enter-code');
+
+  const clickDown = async () => {
+    if (roomId) {
+      await downloadFile(roomId, roomInfo.file_name);
+    }
+  };
+
+  return (
+    <div className="w-full flex flex-col items-center py-20 gap-12">
+      <div
+        className="w-4/5 min-h-[600px] py-8 px-8 flex flex-col items-center
+    shadow-[0px_3px_10px_rgba(0,0,0,0.25)] rounded-2xl gap-8"
+      >
+        <RoomHeader
+          title={roomInfo.title}
+          dateStr={roomInfo.created_at}
+          roomCode={enterCode}
+        />
+        {/* 정렬 및 질문 수 */}
+        <div className="w-full flex justify-center items-center ">
+          <span className="font-semibold  text-[#737373] text-xl">
+            과거 방 조회
+          </span>
+        </div>
+        {/* 질문 목록 */}
+        <div className="w-full flex flex-col items-center gap-6">
+          {dumpData?.map((question) => (
+            // 질문 조회 API 연동 후 isEditable 처리
+            <AdminQuestion
+              roomTitle={''}
+              key={question.question_id}
+              {...question}
+              isAdmin={false}
+              isEditable={true}
+              complete={false}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+export default AdminQuestions;

--- a/src/pages/admin/rooms.tsx
+++ b/src/pages/admin/rooms.tsx
@@ -1,0 +1,101 @@
+import RoomHeader from '../../components/RoomHeader.tsx';
+import Sorting from '../../assets/Sorting.svg?react';
+import { AdminQuestion } from '../../components/AdminQuestion.tsx';
+type Room = {
+  id: string | null;
+  code: string;
+  title: string;
+  created_at: string;
+  file_name: string;
+  room_title: string;
+};
+const AdminRooms = () => {
+  const dumpData: Room[] = [
+    {
+      id: '1',
+      code: '1234',
+      title: 'title 1',
+      created_at: '2025-05-16T09:45:00Z',
+      file_name: '파일 이름 1',
+      room_title: 'Hooks 파헤치기',
+    },
+    {
+      id: '2',
+      code: '5678',
+      title: 'title 2',
+      created_at: '2025-05-16T09:45:00Z',
+      room_title: 'Hooks 파헤치기',
+      file_name: '파일 이름 2',
+    },
+    {
+      id: '3',
+      code: '112233',
+      title: 'title 3',
+      created_at: '2025-05-16T09:45:00Z',
+      file_name: '파일 이름 3',
+      room_title: 'Hooks 파헤치기',
+    },
+    {
+      id: '4',
+      code: '445566',
+      title: 'title 4',
+      created_at: '2025-05-16T09:45:00Z',
+      file_name: '파일 이름 4',
+      room_title: 'Hooks 파헤치기',
+    },
+    {
+      id: '5',
+      code: '778899',
+      title: 'title 5',
+      created_at: '2025-05-16T09:45:00Z',
+      file_name: '파일 이름 5',
+      room_title: 'Hooks 파헤치기',
+    },
+  ];
+  return (
+    <div className="w-full flex flex-col items-center py-20 gap-12">
+      <div
+        className="w-4/5 min-h-[600px] py-8 px-8 flex flex-col items-center
+  shadow-[0px_3px_10px_rgba(0,0,0,0.25)] rounded-2xl gap-8"
+      >
+        <RoomHeader title={'전체 방 조회'} dateStr={''} roomCode={''} />
+        {/* 정렬 및 질문 수 */}
+        <div className="w-full flex justify-between items-center text-[#737373] relative">
+          <div className="flex items-center gap-6">
+            <div
+              className="rounded-xl flex items-center relative
+              px-14 py-3 font-medium border border-[#CFCFCF] cursor-pointer"
+            >
+              <Sorting className="absolute left-7" />
+              <span>Recent</span>
+            </div>
+          </div>
+          <span className="font-semibold text-xl absolute left-1/2 -translate-x-1/2">
+            과거 방 조회
+          </span>
+          <span className="font-semibold">{dumpData.length} Rooms</span>
+        </div>
+        <div className="w-full grid grid-cols-2 gap-6">
+          {dumpData?.map((question) => (
+            <AdminQuestion
+              question_id={
+                isNaN(parseInt(question.id || '0'))
+                  ? 0
+                  : parseInt(question.code)
+              }
+              text={''}
+              likes={0}
+              key={question.id}
+              {...question}
+              isAdmin={true}
+              isEditable={true}
+              complete={true}
+              roomTitle={question.room_title}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+export default AdminRooms;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -44,7 +44,7 @@ const HomePage = () => {
       try {
         const res = await createRoom(roomTitle, fileName);
         setCreateDisabled(true);
-        // navigate(`/room-admin?room-id=${res.room_id}&enter-code=${res.code}`);
+        navigate(`/room-admin?room-id=${res.room_id}&enter-code=${res.code}`);
       } catch (e) {
         console.error(e);
         setCreateDisabled(false);

--- a/src/pages/roomAdmin.tsx
+++ b/src/pages/roomAdmin.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import RoomHeader from '../components/RoomHeader';
 import Sorting from '../assets/Sorting.svg?react';
 import RoomFooter from '../components/RoomFooter';
@@ -8,7 +8,7 @@ import { useSearchParams } from 'react-router-dom';
 import { getRoomInfo, downloadFile } from '../apis/room.ts';
 import { exitRoom } from '../apis/room.ts';
 
-type Room = {
+export type Room = {
   id: string | null;
   code: string;
   title: string;
@@ -147,7 +147,12 @@ const RoomAdmin = () => {
         {/* 질문 목록 */}
         <div className="w-full flex flex-col items-center gap-6">
           {dumpData?.map((question) => (
-            <Question key={question.question_id} {...question} isAdmin={true} />
+            <Question
+              key={question.question_id}
+              {...question}
+              isAdmin={true}
+              isEditable={false}
+            />
           ))}
         </div>
       </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,6 +4,8 @@ import HomePage from '../pages/index';
 import Test from '../pages/test.tsx';
 import RoomAdmin from '../pages/roomAdmin.tsx';
 import RoomStudent from '../pages/roomStudent.tsx';
+import AdminRooms from '../pages/admin/rooms.tsx';
+import AdminQuestions from '../pages/admin/questions.tsx';
 
 const router = createBrowserRouter([
   {
@@ -25,6 +27,14 @@ const router = createBrowserRouter([
       {
         path: '/room-student',
         element: <RoomStudent />,
+      },
+      {
+        path: '/admin/rooms',
+        element: <AdminRooms />,
+      },
+      {
+        path: '/admin/questions/*',
+        element: <AdminQuestions />,
       },
     ],
   },


### PR DESCRIPTION
## #️⃣연관된 이슈

#53 

## 📝작업 내용
### /pages/admin
- rooms.tsx
  - 관리자 과거 방 조회 페이지
  - Question component 복제 후 간결하게 만들어 사용
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/28220705-7f7f-4252-b3dd-65eb85166a36" />

- questions.tsx
  - 관리자 과거 방 질문 조회 페이지
  - Question component 복제 후 간결하게 만들어 사용

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/573742b4-735c-4ef5-a904-151d15bec3cd" />


### src/components
- RoomHeader.tsx
  - 기존 header 에서 분기 처리하여 관리자 페이지에서도 사용할 수 있도록 하였음
  - 날짜 형식에 따라 제대로 처리할 수 있는 형식이면 기존의 header(질문방 생성자, 참여자)로 사용
  - 그렇지 않을 경우 (dateStr 을 빈 칸으로 줌) 보이지 않도록 함
 
<img width="1189" alt="image" src="https://github.com/user-attachments/assets/b7cc12a7-3fe8-495f-ae69-da49c296e618" />

- AdminQuestion.tsx
 - 기존의 Question Component 에서 불필요한 정보를 지우고 외형은 유지하도록 함

<img width="1141" alt="image" src="https://github.com/user-attachments/assets/e1fe7c7f-7858-4b5a-9da6-0ee46beeec5c" />
<img width="1128" alt="image" src="https://github.com/user-attachments/assets/bcd487a8-891f-448c-bf90-26895abdbf39" />
