### PR TITLE
feat: 질문방 생성자 페이지 API 및 웹 소켓 연동

### DIFF
--- a/src/apis/questions.ts
+++ b/src/apis/questions.ts
@@ -7,6 +7,11 @@ export interface QuestionType {
   is_selected?: boolean;
   likes: number;
 }
+type GetQuestionListResponse = {
+  message: string;
+  count: string;
+  questions: QuestionType[];
+};
 
 interface QuestionRes {
   question_id: number;
@@ -15,10 +20,10 @@ interface QuestionRes {
 
 export const getQuestionlist = async (
   roomId: number
-): Promise<QuestionType[] | null> => {
+): Promise<GetQuestionListResponse | null> => {
   try {
-    const response = await axiosInstance.get<QuestionType[]>(
-      `questions/${roomId}`
+    const response = await axiosInstance.get<GetQuestionListResponse>(
+      `rooms/${roomId}/questions`
     );
     return response.data;
   } catch (error) {
@@ -78,5 +83,16 @@ export const deleteQuestion = async (questionId: number) => {
 
     if (code === 403) return `권한 없음: ${msg}`;
     if (code === 404) return `질문을 찾을 수 없음: ${msg}`;
+  }
+};
+
+export const answerQuestion = async (roomId: string, questionId: number) => {
+  try {
+    const response = await axiosInstance.patch(
+      `rooms/${roomId}/questions/${questionId}/status`
+    );
+    return response.data;
+  } catch (error) {
+    console.log('error.response : ', error.response);
   }
 };

--- a/src/apis/room.ts
+++ b/src/apis/room.ts
@@ -17,13 +17,11 @@ export const createRoom = async (title: string, file: string | File) => {
 
 export const enterRoom = async (enterCode: string) => {
   const response = await axios.get(`/rooms?enter-code=${enterCode}`);
-  console.log(response.data);
   return response.data;
-}
+};
 
 export const getRoomInfo = async (enterCode: string) => {
   const response = await axios.get(`/rooms?enter-code=${enterCode}`);
-  console.log(response.data);
   return response.data;
 };
 

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { DotsIcon } from '../assets/DotsIcon';
+import CheckSmall from '../assets/CheckSmall.tsx';
 import { ThumbIcon } from '../assets/ThumbIcon';
 import { UserIcon } from '../assets/UserIcon';
 import { EditQuestion } from './EditQuestion';
@@ -12,6 +13,7 @@ import {
 interface QuestionProps extends QuestionType {
   isAdmin: boolean;
   isEditable: boolean;
+  checkClick: (questions_id: number) => void;
 }
 
 export const Question = ({
@@ -22,6 +24,7 @@ export const Question = ({
   likes,
   isAdmin,
   isEditable,
+  checkClick,
 }: QuestionProps) => {
   const [isLiked, setIsLiked] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
@@ -166,6 +169,14 @@ export const Question = ({
                   }}
                 />
               )}
+            </div>
+          )}
+          {isAdmin && (
+            <div
+              className="w-6 h-5 mr-2 cursor-pointer relative"
+              onClick={() => checkClick(question_id)}
+            >
+              <CheckSmall />
             </div>
           )}
         </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

#56 

## 📝작업 내용
### 질문방 생성자 페이지 API 연동

- 방 입장 직후 웹소켓 연결하여 질문 리스트 조회 및 화면 표시
- 질문 없는 경우 화면 구현
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/d55f02db-37b7-4882-98e9-bbde40c3d4c3" />

- 질문 생성 시 실시간 최신화
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/c80d976e-96d6-44c6-bac4-59fbfbd0e129" />

- 질문 답변 완료 시 제거 후 최신화
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/14d34996-1e4b-49a7-9375-0048fa16ca22" />

- 질문방 닫기 버튼 누를 경우 확인 후 방 닫기 API 호출
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/c804ea9d-ea36-4925-b6ef-c1b69d799b3e" />

## 미해결 Issue
- 창이 닫히는 이벤트 감지 후 비동기 함수 처리 방법을 찾지 못해 우선 방 닫기 버튼에만 API 연동
- 하이라이트: API 구현 이후 연동 예정

