### PR TITLE
feat: 관리자 페이지 전체 방 조회 api 연동

### DIFF
--- a/src/apis/admin.ts
+++ b/src/apis/admin.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import type { Room, Question } from '../types/index.ts';
+
+export async function getAllRooms(): Promise<Room[]> {
+    const res = await axios.get('/api/admin/rooms');
+    return res.data.rooms;
+}
+
+export async function getAdminRoomDetail(roomId: string): Promise<Question[]> {
+    const res = await axios.get(`/api/admin/rooms/${roomId}`);
+    return res.data.questions;
+}

--- a/src/apis/questions.ts
+++ b/src/apis/questions.ts
@@ -6,7 +6,7 @@ export interface QuestionType {
   creator_id: string;
   created_at: string;
   text: string;
-  likes: string;
+  likes: number;
   is_answered?: boolean;
 }
 

--- a/src/apis/questions.ts
+++ b/src/apis/questions.ts
@@ -6,7 +6,7 @@ export interface QuestionType {
   creator_id: string;
   created_at: string;
   text: string;
-  likes: number;
+  likes: string;
   is_answered?: boolean;
 }
 

--- a/src/components/AdminQuestion.tsx
+++ b/src/components/AdminQuestion.tsx
@@ -1,7 +1,5 @@
-import { useState } from 'react';
 import { UserIcon } from '../assets/UserIcon';
 import { type QuestionType } from '../apis/questions';
-import { useNavigate } from 'react-router-dom';
 
 interface QuestionProps extends QuestionType {
   isAdmin: boolean;

--- a/src/components/AdminQuestion.tsx
+++ b/src/components/AdminQuestion.tsx
@@ -1,23 +1,30 @@
 import { useState } from 'react';
 import { UserIcon } from '../assets/UserIcon';
 import { type QuestionType } from '../apis/questions';
+import { useNavigate } from 'react-router-dom';
 
 interface QuestionProps extends QuestionType {
   isAdmin: boolean;
   isEditable: boolean;
   complete: boolean;
   roomTitle: string;
+  onClick?: () => void;
 }
 
 export const AdminQuestion = ({
   text,
   created_at,
-  is_selected,
   isAdmin,
   roomTitle,
+  onClick,
 }: QuestionProps) => {
+
+  // const navigate = useNavigate();
   const handleBoxClick = () => {
     // Todo : 방 이동 처리
+    if (onClick) {
+      onClick(); // ✅ 전달된 경우에만 실행
+    }
   };
 
   const formatDate = (dateStr: string) => {

--- a/src/pages/admin/questions.tsx
+++ b/src/pages/admin/questions.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import RoomHeader from '../../components/RoomHeader';
-import { useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { downloadFile } from '../../apis/room.ts';
 import { AdminQuestion } from '../../components/AdminQuestion.tsx';
 
 export type Room = {
-  id: string | null;
+  room_id: string;
   code: string;
   title: string;
   created_at: string;
@@ -13,55 +13,62 @@ export type Room = {
   room_title: string;
 };
 
+type Question = {
+  question_id: number;
+  text: string;
+  created_at: string;
+  likes: number;
+};
+
 const AdminQuestions = () => {
-  const dumpData = [
-    {
-      question_id: 1,
-      text: '프론트엔드와 백엔드의 가장 큰 차이점은 무엇인가요?',
-      created_at: '2025-05-16T09:00:00Z',
-      is_selected: false,
-      likes: 12,
-    },
-    {
-      question_id: 2,
-      text: 'React에서 상태 관리를 어떤 방식으로 하나요?',
-      created_at: '2025-05-16T09:15:00Z',
-      is_selected: false,
-      likes: 25,
-    },
-    {
-      question_id: 3,
-      text: 'CORS 에러는 왜 발생하고 어떻게 해결하나요?',
-      created_at: '2025-05-16T09:30:00Z',
-      is_selected: false,
-      likes: 8,
-    },
-    {
-      question_id: 4,
-      text: 'TypeScript의 유틸리티 타입 중 가장 자주 쓰는 것은?',
-      created_at: '2025-05-16T09:45:00Z',
-      is_selected: false,
-      likes: 17,
-    },
-  ];
   const [roomInfo, setRoomInfo] = useState<Room>({
-    id: '-1',
+    room_id: '-1',
     code: '-1',
     title: '강의 제목',
     created_at: '',
     file_name: '',
     room_title: '',
   });
+  const [questions, setQuestions] = useState<Question[]>([]);
   const [searchParams] = useSearchParams();
 
-  const roomId = searchParams.get('room-id');
-  const enterCode = searchParams.get('enter-code');
+  const { roomId } = useParams();
+  const enterCode = searchParams.get('code');
+
+  useEffect(() => {
+    const fetchRoomData = async () => {
+      if (!roomId) return;
+
+      try {
+        // 1. 전체 방 목록 가져옴
+        const allRoomsRes = await fetch('/api/admin/rooms');
+        const allRoomsData = await allRoomsRes.json();
+
+        // 2. 해당 roomId에 해당하는 방 정보 추출
+        const matchedRoom = allRoomsData.rooms.find(
+          (room: Room) => room.room_id === roomId
+        );
+
+        if (matchedRoom) setRoomInfo(matchedRoom);
+
+        // 3. 질문 목록 fetch
+        const questionsRes = await fetch(`/api/admin/rooms/${roomId}`);
+        const questionsData = await questionsRes.json();
+        setQuestions(questionsData.questions);
+      } catch (err) {
+        console.error('❌ 방 정보 또는 질문 목록 가져오기 실패:', err);
+      }
+    };
+
+    fetchRoomData();
+  }, [roomId]);
 
   const clickDown = async () => {
     if (roomId) {
       await downloadFile(roomId, roomInfo.file_name);
     }
   };
+
 
   return (
     <div className="w-full flex flex-col items-center py-20 gap-12">
@@ -82,17 +89,24 @@ const AdminQuestions = () => {
         </div>
         {/* 질문 목록 */}
         <div className="w-full flex flex-col items-center gap-6">
-          {dumpData?.map((question) => (
-            // 질문 조회 API 연동 후 isEditable 처리
-            <AdminQuestion
-              roomTitle={''}
-              key={question.question_id}
-              {...question}
-              isAdmin={false}
-              isEditable={true}
-              complete={false}
-            />
+          {questions.map((q) => (
+            roomId && (
+              <AdminQuestion
+                room_id={roomId}
+                roomTitle={roomInfo.title}
+                creator_id={''}
+                question_id={q.question_id.toString()}
+                text={q.text}
+                created_at={q.created_at}
+                likes={q.likes.toString()}
+                isAdmin={true}
+                isEditable={true}
+                complete={true}
+                key={q.question_id}
+              />
+            )
           ))}
+
         </div>
       </div>
     </div>

--- a/src/pages/admin/questions.tsx
+++ b/src/pages/admin/questions.tsx
@@ -2,23 +2,9 @@ import { useEffect, useState } from 'react';
 import RoomHeader from '../../components/RoomHeader';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { downloadFile } from '../../apis/room.ts';
+import { getAllRooms, getAdminRoomDetail } from '../../apis/admin';
 import { AdminQuestion } from '../../components/AdminQuestion.tsx';
-
-export type Room = {
-  room_id: string;
-  code: string;
-  title: string;
-  created_at: string;
-  file_name: string;
-  room_title: string;
-};
-
-type Question = {
-  question_id: number;
-  text: string;
-  created_at: string;
-  likes: number;
-};
+import type { Room, Question } from '../../types/index.ts';
 
 const AdminQuestions = () => {
   const [roomInfo, setRoomInfo] = useState<Room>({
@@ -27,7 +13,6 @@ const AdminQuestions = () => {
     title: '강의 제목',
     created_at: '',
     file_name: '',
-    room_title: '',
   });
   const [questions, setQuestions] = useState<Question[]>([]);
   const [searchParams] = useSearchParams();
@@ -40,21 +25,15 @@ const AdminQuestions = () => {
       if (!roomId) return;
 
       try {
-        // 1. 전체 방 목록 가져옴
-        const allRoomsRes = await fetch('/api/admin/rooms');
-        const allRoomsData = await allRoomsRes.json();
-
-        // 2. 해당 roomId에 해당하는 방 정보 추출
-        const matchedRoom = allRoomsData.rooms.find(
-          (room: Room) => room.room_id === roomId
-        );
-
+        // 모든 방 조회
+        const allRooms = await getAllRooms();
+        // path 파라미터로 전달된 room id와 일치하는 방 정보 조회 (title 가져오기 위함)
+        const matchedRoom = allRooms.find(room => room.room_id === roomId);
         if (matchedRoom) setRoomInfo(matchedRoom);
 
-        // 3. 질문 목록 fetch
-        const questionsRes = await fetch(`/api/admin/rooms/${roomId}`);
-        const questionsData = await questionsRes.json();
-        setQuestions(questionsData.questions);
+        // 특정 room id에 일치하는 방의 모든 질문 조회
+        const questionList = await getAdminRoomDetail(roomId);
+        setQuestions(questionList);
       } catch (err) {
         console.error('❌ 방 정보 또는 질문 목록 가져오기 실패:', err);
       }
@@ -98,7 +77,7 @@ const AdminQuestions = () => {
                 question_id={q.question_id.toString()}
                 text={q.text}
                 created_at={q.created_at}
-                likes={q.likes.toString()}
+                likes={q.likes}
                 isAdmin={true}
                 isEditable={true}
                 complete={true}

--- a/src/pages/admin/rooms.tsx
+++ b/src/pages/admin/rooms.tsx
@@ -3,6 +3,7 @@ import RoomHeader from '../../components/RoomHeader.tsx';
 import Sorting from '../../assets/Sorting.svg?react';
 import { AdminQuestion } from '../../components/AdminQuestion.tsx';
 import { useNavigate } from 'react-router-dom';
+import { getAllRooms} from '../../apis/admin';
 
 type Room = {
   room_id: string;
@@ -20,9 +21,8 @@ const AdminRooms = () => {
   useEffect(() => {
     const fetchRooms = async () => {
       try {
-        const res = await fetch('/api/admin/rooms');
-        const data = await res.json();
-        setRooms(data.rooms); // 서버 응답 형식이 { rooms: [...] }일 경우
+        const data = await getAllRooms();
+        setRooms(data);
       } catch (err) {
         console.error('❌ 방 목록 불러오기 실패:', err);
       } finally {
@@ -62,11 +62,11 @@ const AdminRooms = () => {
           {rooms.map((room) => (
             <AdminQuestion
               key={room.room_id}
-              // <AdminQuestion>의 QuestionType 형식을 맞추기 위한 임의값값
+              // <AdminQuestion>의 QuestionType 형식을 맞추기 위한 임의값
               question_id={''}
               creator_id={''}
               text={''}
-              likes={'0'}
+              likes={0}
 
               {...room}
               isAdmin={true}

--- a/src/pages/admin/rooms.tsx
+++ b/src/pages/admin/rooms.tsx
@@ -1,57 +1,40 @@
+import React, { useEffect, useState } from 'react';
 import RoomHeader from '../../components/RoomHeader.tsx';
 import Sorting from '../../assets/Sorting.svg?react';
 import { AdminQuestion } from '../../components/AdminQuestion.tsx';
+import { useNavigate } from 'react-router-dom';
+
 type Room = {
-  id: string | null;
+  room_id: string;
   code: string;
   title: string;
   created_at: string;
   file_name: string;
-  room_title: string;
 };
 const AdminRooms = () => {
-  const dumpData: Room[] = [
-    {
-      id: '1',
-      code: '1234',
-      title: 'title 1',
-      created_at: '2025-05-16T09:45:00Z',
-      file_name: '파일 이름 1',
-      room_title: 'Hooks 파헤치기',
-    },
-    {
-      id: '2',
-      code: '5678',
-      title: 'title 2',
-      created_at: '2025-05-16T09:45:00Z',
-      room_title: 'Hooks 파헤치기',
-      file_name: '파일 이름 2',
-    },
-    {
-      id: '3',
-      code: '112233',
-      title: 'title 3',
-      created_at: '2025-05-16T09:45:00Z',
-      file_name: '파일 이름 3',
-      room_title: 'Hooks 파헤치기',
-    },
-    {
-      id: '4',
-      code: '445566',
-      title: 'title 4',
-      created_at: '2025-05-16T09:45:00Z',
-      file_name: '파일 이름 4',
-      room_title: 'Hooks 파헤치기',
-    },
-    {
-      id: '5',
-      code: '778899',
-      title: 'title 5',
-      created_at: '2025-05-16T09:45:00Z',
-      file_name: '파일 이름 5',
-      room_title: 'Hooks 파헤치기',
-    },
-  ];
+  const [rooms, setRooms] = useState<Room[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchRooms = async () => {
+      try {
+        const res = await fetch('/api/admin/rooms');
+        const data = await res.json();
+        setRooms(data.rooms); // 서버 응답 형식이 { rooms: [...] }일 경우
+      } catch (err) {
+        console.error('❌ 방 목록 불러오기 실패:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRooms();
+  }, []);
+
+  if (loading) return <div>로딩 중...</div>;
+
   return (
     <div className="w-full flex flex-col items-center py-20 gap-12">
       <div
@@ -73,24 +56,24 @@ const AdminRooms = () => {
           <span className="font-semibold text-xl absolute left-1/2 -translate-x-1/2">
             과거 방 조회
           </span>
-          <span className="font-semibold">{dumpData.length} Rooms</span>
+          <span className="font-semibold">{rooms.length} Rooms</span>
         </div>
         <div className="w-full grid grid-cols-2 gap-6">
-          {dumpData?.map((question) => (
+          {rooms.map((room) => (
             <AdminQuestion
-              question_id={
-                isNaN(parseInt(question.id || '0'))
-                  ? 0
-                  : parseInt(question.code)
-              }
+              key={room.room_id}
+              // <AdminQuestion>의 QuestionType 형식을 맞추기 위한 임의값값
+              question_id={''}
+              creator_id={''}
               text={''}
-              likes={0}
-              key={question.id}
-              {...question}
+              likes={'0'}
+
+              {...room}
               isAdmin={true}
               isEditable={true}
               complete={true}
-              roomTitle={question.room_title}
+              roomTitle={room.title}
+              onClick={() => navigate(`/admin/rooms/${room.room_id}?code=${room.code}`)}
             />
           ))}
         </div>

--- a/src/pages/socketTest.tsx
+++ b/src/pages/socketTest.tsx
@@ -21,6 +21,7 @@ export default function RoomTestPage() {
   const [questions, setQuestions] = useState<Question[]>([]);
   const [roomClosed, setRoomClosed] = useState(false);
   const [roomId, setRoomId] = useState<number | null>(null)
+  const [highlightedId, setHighlightedId] = useState<string | null>(null);
 
   // 방 입장
   const handleJoin = (roomId: number) => {
@@ -194,7 +195,16 @@ export default function RoomTestPage() {
     };
   }, [socket]);
 
+  // 하이라이트 실시간 반영
+  useEffect(() => {
+    socket.on('receiveHighlight', (data: { question_id: string }) => {
+      setHighlightedId(data.question_id);
+    });
 
+    return () => {
+      socket.off('receiveHighlight');
+    };
+  }, []);
 
   return (
     <div style={{ padding: 20 }}>
@@ -218,21 +228,30 @@ export default function RoomTestPage() {
       <h4>📋 질문 목록</h4>
       <ul>
         {questions.map((q) => {
-          // responseBody에 포함된 값 전체를 받아오되, 화면에 표시하고 싶은 일부 속성만 골라서 출력
-          const { text, likes, created_at } = q;
+          const { text, likes, created_at, question_id } = q;
+          const isHighlighted = highlightedId === question_id.toString();
+
           return (
-            <li key={q.question_id}>
+            <li
+              key={question_id}
+              style={{
+                backgroundColor: isHighlighted ? '#fff7d6' : 'transparent', // 연노랑 강조
+                border: isHighlighted ? '2px solid orange' : '1px solid #ccc',
+                padding: '8px',
+                marginBottom: '8px',
+              }}
+            >
               <div><strong>질문:</strong> {text}</div>
               <div>
                 <strong>좋아요:</strong> {likes}
-                <button onClick={() => handleLike(q.question_id)}>좋아요 👍</button>
+                <button onClick={() => handleLike(question_id)}>좋아요 👍</button>
               </div>
               <div><strong>작성 시간:</strong> {new Date(created_at).toLocaleString('ko-KR')}</div>
-              <hr />
             </li>
           );
         })}
       </ul>
+
     </div>
   );
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -32,12 +32,11 @@ const router = createBrowserRouter([
         element: <RoomStudent />,
       },
       {
-
         path: '/admin/rooms',
         element: <AdminRooms />,
       },
       {
-        path: '/admin/questions/*',
+        path: '/admin/rooms/:roomId',
         element: <AdminQuestions />,
       },
       {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,14 @@
+export type Room = {
+  room_id: string;
+  code: string;
+  title: string;
+  created_at: string;
+  file_name: string;
+};
+
+export type Question = {
+  question_id: number;
+  text: string;
+  created_at: string;
+  likes: number;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈
#57 #54 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
![1](https://github.com/user-attachments/assets/be06fda8-ebc1-4c2d-8bc4-1a25fbc7fb61)
## 전체 방 정보 조회  
- /api/admin/rooms 호출하여 전체 방 리스트 fetch  
  
![2](https://github.com/user-attachments/assets/469be6a6-56ba-44f6-9382-7720db0bcd6d)
![3](https://github.com/user-attachments/assets/bea6bf71-c786-4eb3-a538-9ce332b0e796)

## 특정 방 질문 리스트 조회
- useParams()를 통해 roomId path 파라미터 추출
- useSearchParams()를 통해 code 쿼리 파라미터 추출
- 선택된 방의 정보를 /api/admin/rooms 전체 리스트에서 필터링하여 추출
- 해당 방의 질문 목록을 /api/admin/rooms/:roomId API로 fetch

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
