### PR TITLE
[Feat] 질문방 강연자 페이지 하이라이트 API 연동

### DIFF
--- a/src/apis/questions.ts
+++ b/src/apis/questions.ts
@@ -1,4 +1,5 @@
 import axiosInstance from './axiosInstance';
+import axios from 'axios';
 
 export interface QuestionType {
   room_id: string;
@@ -95,13 +96,38 @@ export const deleteQuestion = async (questionId: number, roomId: number) => {
   }
 };
 
-export const answerQuestion = async (roomId: string, questionId: number) => {
+export const answerQuestion = async (roomId: string, questionId: string) => {
   try {
     const response = await axiosInstance.patch(
       `rooms/${roomId}/questions/${questionId}/status`
     );
     return response.data;
-  } catch (error) {
-    console.log('error.response : ', error.response);
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      console.log('error.response : ', error.response);
+    } else {
+      console.error('Unexpected error', error);
+    }
+  }
+};
+
+export const highlightQuestion = async (
+  roomId: string | null,
+  questionId: string
+) => {
+  try {
+    if (roomId) {
+      return await axiosInstance.patch(`admin/rooms/${roomId}`, {
+        question_id: questionId,
+      });
+    } else {
+      console.log('roomId 없음');
+    }
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      console.log('error.response : ', error.response);
+    } else {
+      console.error('Unexpected error', error);
+    }
   }
 };

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -13,7 +13,7 @@ import { postLike, deleteLike } from '../apis/like';
 import { useSearchParams } from 'react-router-dom';
 
 interface QuestionProps extends QuestionType {
-  checkClick?: (questions_id: string) => void;
+  checkClick: (questions_id: string) => void;
   isLecturer: boolean;
   visitorId?: string;
   roomSocketId?: string | null;
@@ -107,11 +107,6 @@ export const Question = ({
       setIsLiked((prev) => !prev);
       setLikeCount((prev) => prev + (newLikeState ? -1 : 1));
       alert(result.message);
-    }
-  };
-  const gun = () => {
-    if (checkClick) {
-      checkClick(question_id);
     }
   };
 
@@ -220,7 +215,7 @@ export const Question = ({
               className="w-6 h-5 mr-2 cursor-pointer relative"
               onClick={(e) => {
                 e.stopPropagation();
-                gun();
+                checkClick(question_id);
               }}
             >
               <CheckSmall />

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { DotsIcon } from '../assets/DotsIcon';
 import CheckSmall from '../assets/CheckSmall.tsx';
 import { ThumbIcon } from '../assets/ThumbIcon';
@@ -17,6 +17,7 @@ interface QuestionProps extends QuestionType {
   isLecturer: boolean;
   visitorId?: string;
   roomSocketId?: string | null;
+  clickBox?: (questions_id: string) => void;
 }
 
 export const Question = ({
@@ -29,6 +30,7 @@ export const Question = ({
   is_answered,
   isLecturer,
   visitorId,
+  clickBox,
 }: QuestionProps) => {
   const [isLiked, setIsLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(likes);
@@ -41,10 +43,15 @@ export const Question = ({
   const roomId = searchParams.get('room-id') || '';
 
   //선택한 질문 하이라이팅
-  const handleBoxClick = () => {
+  const handleBoxClick = (questionId: string) => {
+    console.log('handleBoxClick 실행');
     if (!isLecturer) return;
-    setSelectedBox((prev) => !prev);
+    if (clickBox) clickBox(questionId);
   };
+
+  useEffect(() => {
+    setSelectedBox(is_answered);
+  }, [is_answered]);
 
   //수정 확인
   const handleSave = async () => {
@@ -103,14 +110,14 @@ export const Question = ({
     }
   };
   const gun = () => {
-    if(checkClick){
-      checkClick(question_id)
+    if (checkClick) {
+      checkClick(question_id);
     }
-  }
+  };
 
   return (
     <div
-      onClick={handleBoxClick}
+      onClick={() => handleBoxClick(question_id)}
       className={`flex flex-row w-full h-fit py-4 px-8 rounded-2xl shadow-[0_0_4px_1px_rgba(51,196,168,0.75)] 
         ${selectedBox ? 'bg-[#E1F4F0]' : 'bg-white'}
         ${isLecturer ? 'cursor-pointer' : ''}
@@ -211,7 +218,10 @@ export const Question = ({
           {isLecturer && (
             <div
               className="w-6 h-5 mr-2 cursor-pointer relative"
-              onClick={() => gun()}
+              onClick={(e) => {
+                e.stopPropagation();
+                gun();
+              }}
             >
               <CheckSmall />
             </div>
@@ -221,3 +231,5 @@ export const Question = ({
     </div>
   );
 };
+
+//

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -1,0 +1,33 @@
+import type { QuestionType } from '../apis/questions.ts';
+
+export const sortedByLikes = (
+  questions: QuestionType[],
+  highlightedId?: string | null
+) => {
+  return [...questions].sort((a, b) => {
+    if (highlightedId) {
+      if (a.question_id === highlightedId) {
+        a.is_answered = true;
+      }
+      if (a.question_id === highlightedId) return -1;
+      if (b.question_id === highlightedId) return 1;
+    }
+    return parseInt(String(b.likes)) - parseInt(String(a.likes));
+  });
+};
+
+export const sortedByCreatedAt = (
+  questions: QuestionType[],
+  highlightedId?: string | null
+) => {
+  return [...questions].sort((a, b) => {
+    if (highlightedId) {
+      if (a.question_id === highlightedId) {
+        a.is_answered = true;
+      }
+      if (a.question_id === highlightedId) return -1;
+      if (b.question_id === highlightedId) return 1;
+    }
+    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+  });
+};

--- a/src/pages/roomAdmin.tsx
+++ b/src/pages/roomAdmin.tsx
@@ -92,6 +92,7 @@ const RoomAdmin = () => {
   }, [roomId]);
 
   useEffect(() => {
+    // 질문 추가
     const handleReceiveQuestion = (newQuestion: QuestionType) => {
       setQuestions((prev) => {
         const updated = [...prev, newQuestion];
@@ -108,10 +109,11 @@ const RoomAdmin = () => {
       e.returnValue = '';
     };
 
+    // 질문 수정
     const handleUpdate = ({ question }: { question: QuestionType }) => {
       setQuestions((prev) => {
         const updated = prev.map((q) => {
-          if (String(q.question_id) === String(question.question_id)) {
+          if (q.question_id === question.question_id) {
             return {
               ...question,
               is_answered: q.question_id === highlightedIdRef.current,
@@ -126,6 +128,7 @@ const RoomAdmin = () => {
       });
     };
 
+    // 질문 삭제
     const handleDeleteQuestion = ({ question_id }: { question_id: string }) => {
       setQuestions((prev) => {
         const updated = prev.filter(
@@ -139,9 +142,37 @@ const RoomAdmin = () => {
       }
     };
 
+    const handleLikes = ({
+      questionId,
+      likes,
+    }: {
+      questionId: number;
+      likes: number;
+    }) => {
+      console.log('걸리니??');
+
+      setQuestions((prev) => {
+        const updated = prev.map((q) => {
+          if (String(q.question_id) === String(questionId)) {
+            return {
+              ...q,
+              is_answered: q.question_id === highlightedIdRef.current,
+              likes: likes,
+            };
+          }
+          return q;
+        });
+
+        return isRecentRef.current
+          ? sortedByCreatedAt(updated, highlightedIdRef.current)
+          : sortedByLikes(updated, highlightedIdRef.current);
+      });
+    };
+
     socket.on('receiveQuestion', handleReceiveQuestion);
     socket.on('updateQuestion', handleUpdate);
     socket.on('deleteQuestion', handleDeleteQuestion);
+    socket.on('updateLikes', handleLikes);
 
     socket.on('receiveHighlight', (data: { question_id: string }) => {
       setHighlightedId(data.question_id);
@@ -152,6 +183,9 @@ const RoomAdmin = () => {
     return () => {
       socket.off('receiveQuestion', handleReceiveQuestion);
       socket.off('receiveHighlight');
+      socket.off('updateQuestion', handleUpdate);
+      socket.off('deleteQuestion', handleDeleteQuestion);
+      socket.off('updateLikes', handleLikes);
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, []);

--- a/src/pages/roomAdmin.tsx
+++ b/src/pages/roomAdmin.tsx
@@ -9,10 +9,11 @@ import { downloadFile, exitRoom, getRoomInfo } from '../apis/room.ts';
 import {
   answerQuestion,
   getQuestionlist,
+  highlightQuestion,
   type QuestionType,
 } from '../apis/questions.ts';
 import socket from '../lib/socket.ts'; // socket.ts 유지
-
+import { sortedByLikes, sortedByCreatedAt } from '../lib/questions.ts';
 export type Room = {
   id: string | null;
   code: string;
@@ -22,36 +23,6 @@ export type Room = {
 };
 
 const RoomAdmin = () => {
-  const dumpData = [
-    {
-      question_id: 1,
-      text: '프론트엔드와 백엔드의 가장 큰 차이점은 무엇인가요?',
-      created_at: '2025-05-16T09:00:00Z',
-      is_selected: false,
-      likes: 12,
-    },
-    {
-      question_id: 2,
-      text: 'React에서 상태 관리를 어떤 방식으로 하나요?',
-      created_at: '2025-05-16T09:15:00Z',
-      is_selected: true,
-      likes: 25,
-    },
-    {
-      question_id: 3,
-      text: 'CORS 에러는 왜 발생하고 어떻게 해결하나요?',
-      created_at: '2025-05-16T09:30:00Z',
-      is_selected: false,
-      likes: 8,
-    },
-    {
-      question_id: 4,
-      text: 'TypeScript의 유틸리티 타입 중 가장 자주 쓰는 것은?',
-      created_at: '2025-05-16T09:45:00Z',
-      is_selected: false,
-      likes: 17,
-    },
-  ];
   const [isLive, setLive] = useState(false);
   const [roomInfo, setRoomInfo] = useState<Room>({
     id: '-1',
@@ -64,6 +35,9 @@ const RoomAdmin = () => {
   const [connected, setConnected] = useState(false);
   const [roomSocketId, setRoomSocketId] = useState<string | null>(null);
   const [isRecent, setIsRecent] = useState(true);
+  const [highlightedId, setHighlightedId] = useState<string | null>(null);
+  const highlightedIdRef = useRef<string | null>(null);
+
   const isRecentRef = useRef(isRecent);
   useEffect(() => {
     isRecentRef.current = isRecent;
@@ -99,9 +73,9 @@ const RoomAdmin = () => {
         const res = await getQuestionlist(parseInt(roomId));
         if (res) {
           if (isRecent) {
-            setQuestions(sortedByCreatedAt(res));
+            setQuestions(sortedByCreatedAt(res, highlightedId));
           } else {
-            setQuestions(sortedByLikes(res));
+            setQuestions(sortedByLikes(res, highlightedId));
           }
         }
       }
@@ -122,44 +96,96 @@ const RoomAdmin = () => {
       setQuestions((prev) => {
         const updated = [...prev, newQuestion];
         if (isRecentRef.current) {
-          return sortedByCreatedAt(updated);
+          return sortedByCreatedAt(updated, highlightedIdRef.current);
         } else {
-          return sortedByLikes(updated);
+          return sortedByLikes(updated, highlightedIdRef.current);
         }
       });
     };
+
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       e.preventDefault();
       e.returnValue = '';
     };
 
+    const handleUpdate = ({ question }: { question: QuestionType }) => {
+      setQuestions((prev) => {
+        const updated = prev.map((q) => {
+          if (String(q.question_id) === String(question.question_id)) {
+            return {
+              ...question,
+              is_answered: q.question_id === highlightedIdRef.current,
+            };
+          }
+          return q;
+        });
+
+        return isRecentRef.current
+          ? sortedByCreatedAt(updated, highlightedIdRef.current)
+          : sortedByLikes(updated, highlightedIdRef.current);
+      });
+    };
+
+    const handleDeleteQuestion = ({ question_id }: { question_id: string }) => {
+      setQuestions((prev) => {
+        const updated = prev.filter(
+          (q) => String(q.question_id) !== String(question_id)
+        );
+        return updated;
+      });
+
+      if (highlightedId === question_id) {
+        setHighlightedId(null);
+      }
+    };
+
     socket.on('receiveQuestion', handleReceiveQuestion);
+    socket.on('updateQuestion', handleUpdate);
+    socket.on('deleteQuestion', handleDeleteQuestion);
+
+    socket.on('receiveHighlight', (data: { question_id: string }) => {
+      setHighlightedId(data.question_id);
+    });
+
     window.addEventListener('beforeunload', handleBeforeUnload);
 
     return () => {
       socket.off('receiveQuestion', handleReceiveQuestion);
+      socket.off('receiveHighlight');
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, []);
 
-  const sortedByCreatedAt = (questions: QuestionType[]) => {
-    return [...questions].sort(
-      (a, b) =>
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-    );
-  };
-  const sortedByLikes = (questions: QuestionType[]) => {
-    return [...questions].sort(
-      (a, b) => parseInt(String(b.likes)) - parseInt(String(a.likes))
-    );
-  };
+  useEffect(() => {
+    highlightedIdRef.current = highlightedId;
+  }, [highlightedId]);
+
   useEffect(() => {
     if (isRecent) {
-      setQuestions(sortedByCreatedAt(questions));
+      setQuestions(sortedByCreatedAt(questions, highlightedId));
     } else {
-      setQuestions(sortedByLikes(questions));
+      setQuestions(sortedByLikes(questions, highlightedId));
     }
   }, [isRecent]);
+
+  useEffect(() => {
+    if (!highlightedId) return;
+
+    setQuestions((prev) => {
+      const updated = prev.map((q) => ({
+        ...q,
+        is_answered: q.question_id === highlightedId,
+      }));
+
+      const sorted = updated.sort((a, b) => {
+        if (a.question_id === highlightedId) return -1;
+        if (b.question_id === highlightedId) return 1;
+        return 0;
+      });
+
+      return sorted;
+    });
+  }, [highlightedId]);
 
   const joinRoom = () => {
     if (!roomId) return;
@@ -189,16 +215,16 @@ const RoomAdmin = () => {
     }
   };
 
-  const clickCheck = async (questionId: number) => {
+  const clickCheck = async (questionId: string) => {
     if (roomId && questionId) {
       const res = await answerQuestion(roomId, questionId);
       if (res) {
         const updated = await getQuestionlist(parseInt(roomId));
         if (updated) {
           if (isRecent) {
-            setQuestions(sortedByCreatedAt(updated));
+            setQuestions(sortedByCreatedAt(updated, highlightedId));
           } else {
-            setQuestions(sortedByLikes(updated));
+            setQuestions(sortedByLikes(updated, highlightedId));
           }
         }
       }
@@ -223,6 +249,9 @@ const RoomAdmin = () => {
   // view as participant 버튼 클릭
   const viewClick = () => {
     console.log('viewClick');
+  };
+  const handleHighLight = async (questionId: string) => {
+    await highlightQuestion(roomId, questionId);
   };
 
   return (
@@ -256,7 +285,7 @@ const RoomAdmin = () => {
               <span>자료 다운로드</span>
             </div>
           </div>
-          <span className="font-semibold">{dumpData.length} Questions</span>
+          <span className="font-semibold">{questions.length} Questions</span>
         </div>
         {/* 질문 목록 */}
         <div className="w-full flex flex-col items-center gap-6">
@@ -266,6 +295,8 @@ const RoomAdmin = () => {
               {...question}
               isLecturer={true}
               checkClick={clickCheck}
+              clickBox={handleHighLight}
+              is_answered={question.is_answered}
             />
           ))}
           {(!questions || questions.length === 0) && (


### PR DESCRIPTION
## #️⃣연관된 이슈

#68 
## 📝작업 내용
### 강연자 - 질문 선택 시 하이라이트 및 질문 상단 배치
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/5c9b98d6-b0f7-4f74-84d2-80f148957b1a" />

- delete, highlight, update, add 등 web socket 이벤트 리스너들에 highlight 객체 유지 기능 추가
- sort 함수에 highlight_id 추가 및 함수 lib 디렉토리로 분리 관리